### PR TITLE
update checkout to v4

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -27,7 +27,7 @@ runs:
   steps:
     - uses: actions/checkout@v4
     - name: "Setup Python ${{ inputs.python_version }}"
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python_version }}
     

--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: "Setup Python ${{ inputs.python_version }}"
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
Avoid the node deprication warning when using the action, it's the last warning [here](https://github.com/colevandersWands/testing-python-actions/actions/runs/11508394402)